### PR TITLE
Using defonce instead of def for config

### DIFF
--- a/src/taoensso/tower.clj
+++ b/src/taoensso/tower.clj
@@ -13,8 +13,8 @@
 
 (declare compiled-dictionary)
 
-(def config
-  "This map controls everything about the way Tower operates.
+(defonce
+  ^{:doc "This map controls everything about the way Tower operates.
 
   To enable translations, :dictionary should be a map of form
   {:locale {:ns1 ... {:nsN {:key<.optional-decorator> text}}}}}
@@ -26,7 +26,8 @@
     :dev-mode? which controls Ring middleware's automatic dictionary reloading
     and the behaviour of default missing-translation function.
 
-  See source code for further details."
+  See source code for further details."}
+  config
   (atom {:dev-mode?      true
          :default-locale :en
 


### PR DESCRIPTION
Using defonce instead of def, as defonce will cause re-evaluation of the atom and setting it to the default value when namespace is referenced more than once.
