### PR TITLE
Removing Timbre from dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,7 @@
   :description "Simple internationalization (i18n) library for Clojure."
   :url "https://github.com/ptaoussanis/tower"
   :license {:name "Eclipse Public License"}
-  :dependencies [[org.clojure/clojure "1.3.0"]
-                 [com.taoensso/timbre "0.6.0"]]
+  :dependencies [[org.clojure/clojure "1.3.0"]]
   :profiles {:1.3   {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4   {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5   {:dependencies [[org.clojure/clojure "1.5.0-master-SNAPSHOT"]]}

--- a/src/taoensso/tower.clj
+++ b/src/taoensso/tower.clj
@@ -3,8 +3,7 @@
   functionality when possible, removing unnecessary boilerplate."
   {:author "Peter Taoussanis"}
   (:require [clojure.string  :as str]
-            [clojure.java.io :as io]
-            [taoensso.timbre :as timbre])
+            [clojure.java.io :as io])
   (:use     [taoensso.tower.utils :as utils :only (defmem-)])
   (:import  [java.util Date Locale TimeZone]
             [java.text Collator NumberFormat DateFormat]))
@@ -49,7 +48,7 @@
            (let [{:keys [dev-mode? default-locale]} @config]
              (if dev-mode?
              (str "**" key "**")
-             (do (timbre/error "Missing translation" key "for" locale)
+             (do (println "Missing translation" key "for" locale)
                  (get-in @compiled-dictionary [default-locale key]
                          "")))))}))
 


### PR DESCRIPTION
Loosing dependecies a bit by removing timbre. 
It loads postal, and as far as I can see right now it's used only once to write the translation missing error.

Maybe it would be a good idea to allow error logging customization on user level? For example, we're using eventoverse and clojure.log top of slf4j-log4j... 

thanks for the great library! works smoothly so far!
