### PR TITLE
Allow aliases in dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Here Tower diverges from the standard Java approach in favour of something simpl
                          :bar {:baz ":en :example.bar/baz text"}
                          :greeting  "Hello {0}, how are you?"
                          :with-markdown "<tag>**strong**</tag>"
-                         :with-exclaim! "<tag>**strong**</tag>"}}
+                         :with-exclaim! "<tag>**strong**</tag>"}
                :missing  "<Translation missing: {0}>"}
   :en-US      {:example {:foo ":en-US :example/foo text"}}
   :en-US-var1 {:example {:foo ":en-US-var1 :example/foo text"}}}


### PR DESCRIPTION
Peter,

What do you think to aliases in dictionaries:

```
 {:en  {:example {
    :bar {:baz ":en :example.bar/baz text"}
    :greeting  "Hello {0}, how are you?"
    :yo :example/greeting
    :baz2 :example.bar/baz}
```

Usage:

```
(with-locale :en
  (is (= (t :example/yo "Bob") "Hello Bob, how are you?"))
  (is (= (t :example/baz2) (t :example.bar/baz))))
```

?

Benefits:
- A little more flexibility when maintaining large translation files - e.g. you can leave legacy keys in place and not update all the code that uses them at that time.
- You might use scopes to define a set of standard keys for a repeating class of things, but want to share the translation values.
- General DRYness.

If you like this, you might also consider allowing 

```
...
:bar2 :bar}
....
(is (= (t :example.bar2/baz) (t :example.bar/baz)))
```

\- Phil
