### PR TITLE
Translation aliases

### DIFF
--- a/test/test_tower/main.clj
+++ b/test/test_tower/main.clj
@@ -154,4 +154,9 @@
     (is (= (t :invalid "arg") "&lt;Missing translation: {:locale :en, :scope nil, :k-or-ks :invalid}&gt;"))
     (is (= (t [:invalid :example/foo]) ":en :example/foo text"))
     (is (= (t [:invalid "Explicit fallback"]) "Explicit fallback"))
-    (is (= (t [:invalid nil]) nil))))
+    (is (= (t [:invalid nil]) nil)))
+
+  ;; Aliases
+  (with-locale :en
+    (is (= (t :example/yo "Bob") "Hello Bob, how are you?"))
+    (is (= (t :example/baz2) (t :example.bar/baz)))))


### PR DESCRIPTION
Peter,

What do you think to aliases in dictionaries:

```
 {:en  {:example {
    :bar {:baz ":en :example.bar/baz text"}
    :greeting  "Hello {0}, how are you?"
    :yo :example/greeting
    :baz2 :example.bar/baz}
```

Usage:

```
(with-locale :en
  (is (= (t :example/yo "Bob") "Hello Bob, how are you?"))
  (is (= (t :example/baz2) (t :example.bar/baz))))
```

?

Benefits:
- A little more flexibility when maintaining large translation files - e.g. you can leave legacy keys in place and not update all the code that uses them at that time.
- You might use scopes to define a set of standard keys for a repeating class of things, but want to share the translation values.
- General DRYness.

If you like this, you might also consider allowing 

```
...
:bar2 :bar}
....
(is (= (t :example.bar2/baz) (t :example.bar/baz)))
```

\- Phil
