### PR TITLE
Adding use of .getMessage for reporting dict-load exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /pom.xml*
 /.env
 .DS_Store
+.idea
+tower.iml

--- a/src/taoensso/tower.cljx
+++ b/src/taoensso/tower.cljx
@@ -536,7 +536,8 @@
             (try (-> dict io/resource io/reader slurp read-string)
                  (catch Exception e
                    (throw (ex-info (str "Failed to load dictionary from resource: " dict)
-                            {:dict dict} e))))))]
+                            {:dict dict
+                             :message (.getMessage e)} e))))))]
     (fn [dict]
       (let [;; Load top-level dict:
             dict (encore/have map? (load1 dict))]


### PR DESCRIPTION
The current error handler for dict-load was masking the Clojure
error messages, which typically tell you exactly is wrong with the
map parsing. (Duplicate keys, unmatched brackets, etc...) This PR
now uses .getMessage to show the original message of the exception.
